### PR TITLE
Fix spelling mistake in Entity

### DIFF
--- a/lib/entity.js
+++ b/lib/entity.js
@@ -49,7 +49,7 @@ module.exports = class Entity {
     }
 
     is (entity) {
-        return store.get('entites').get(this).has(entity);
+        return store.get('entities').get(this).has(entity);
     }
 
     destroy (entity) {


### PR DESCRIPTION
This PR fixes the `is` method in Entity which was accidentally getting `entites` instead of `entities`.